### PR TITLE
Fixes for running with OpenJ9

### DIFF
--- a/PlayOutAgent/rtlib/de/bodden/tamiflex/playout/rt/ReflLogger.java
+++ b/PlayOutAgent/rtlib/de/bodden/tamiflex/playout/rt/ReflLogger.java
@@ -160,24 +160,17 @@ public class ReflLogger {
 		try {
 			StackTraceElement frame = getInvokingFrame();
 			String[] paramTypes = classesToTypeNames(c.getParameterTypes());
-			String className = c.getDeclaringClass().getName();
-			// If this is a lambda proxy class the className comes out in the form:
-			// "<dotted package>.<class>$$Lambda$<count>/<hash code>",
-			// however, when we take its byte code to generate the class name (as happens when we 
-			// dump the classes to disk) the name does not contain the "/<hash code>".
-			// This logic below is to remove the hash code so the reflection log entries match
-			// the classes that are dumped and soot can process them.
-			if (className.contains("$$Lambda$"))
+			String declareClassName = c.getDeclaringClass().getName();
+			// Lambda's declaring class name comes out as: "<dotted package>.<class>$$Lambda$<count>/<number>",
+			// however we write out the lambda class as "<dotted package>.<class>$$Lambda$<count>.class"
+			// We need to remove "/<number>" so the reflection log entry matches the class file name.
+			if (declareClassName.contains("$$Lambda$"))
 			{
-				String slashHashCode = "/" + c.getDeclaringClass().hashCode();
-				if (!className.endsWith(slashHashCode)) {
-					System.err.println("unexpected lambda proxy class: " + className);
-				}
-				else {
-					className = className.substring(0, className.length() - slashHashCode.length());
-				}
+				int ignoreStart = declareClassName.lastIndexOf('/');
+				if (ignoreStart != -1)
+					declareClassName = declareClassName.substring(0, ignoreStart);
 			}
-			logAndIncrementTargetMethodEntry(frame.getClassName()+"."+frame.getMethodName(),frame.getLineNumber(),constructorMethodKind,className,"void","<init>", c.isAccessible(), paramTypes);
+			logAndIncrementTargetMethodEntry(frame.getClassName()+"."+frame.getMethodName(),frame.getLineNumber(),constructorMethodKind,declareClassName,"void","<init>", c.isAccessible(), paramTypes);
 
 		} finally {
 			leavingReflectionAPI();

--- a/PlayOutAgent/src/de/bodden/tamiflex/playout/ReflectionMonitor.java
+++ b/PlayOutAgent/src/de/bodden/tamiflex/playout/ReflectionMonitor.java
@@ -77,7 +77,7 @@ public class ReflectionMonitor implements ClassFileTransformer {
 		
 		try {
 			final ClassReader creader = new ClassReader(classfileBuffer);
-			final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS);
+			final ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
 			ClassVisitor visitor = writer;
 			
 			for (AbstractTransformation transformation : transformations)


### PR DESCRIPTION
Fixes #11 and also reverts a0f1272cb2bd205bde3082ad73c82fdb5ae6a43d which made the the lambda proxy class matching too specific to HotSpot. 

#11 is caused by bytecode verification failure in OpenJ9. 

Thanks to [Cheng](https://github.com/ChengJin01) from the OpenJ9 team for finding out that the  failure is caused due to empty stack map tables for the transformed classes.